### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/pug-mode.el
+++ b/pug-mode.el
@@ -15,7 +15,7 @@
 ;; Version: 1.0.4
 ;; Homepage: https://github.com/hlissner/emacs-pug-mode
 ;; Keywords: markup, language, jade, pug
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((emacs "24.3"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
- user-error and setq-local were introduced at Emacs 24.3
- cl-lib is bundled since Emacs 24.3