### PR TITLE
Proposing an alternative method for calling pug-compile on saved files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ developers!
 ## Auto-compiling pug files
 
 This plugin introduces a `pug-compile` function. You can call it
-directly (e.g. `M-x pug-compile`) or have it done automatically for .pug files (as per [this Reddit post:](https://www.reddit.com/r/emacs/comments/741tx6/how_to_change_default_findfile_action_for/))
+directly (e.g. `M-x pug-compile`) or have it done automatically for .pug files:
 
 ```(defun pug-compile-saved-file()
   (when (and (stringp buffer-file-name)

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ developers!
 ## Auto-compiling pug files
 
 This plugin introduces a `pug-compile` function. You can call it
-directly (e.g. `M-x pug-compile`) or have it done automatically:
+directly (e.g. `M-x pug-compile`) or have it done automatically for .pug files (as per [this Reddit post:](https://www.reddit.com/r/emacs/comments/741tx6/how_to_change_default_findfile_action_for/))
 
-`(add-hook 'after-save-hook #'pug-compile)`
+```(defun pug-compile-saved-file()
+  (when (and (stringp buffer-file-name)
+             (string-match "\\.pug\\'" buffer-file-name))
+     (pug-compile)))
+(add-hook 'after-save-hook 'pug-compile-saved-file)```
 
 It requires [pug-cli](https://www.npmjs.com/package/pug-cli).
 


### PR DESCRIPTION
The original code snippet had Emacs outputting "not in a pug-mode buffer" every time a generic buffer was saved. This function (as per this [Reddit thread](https://www.reddit.com/r/emacs/comments/741tx6/how_to_change_default_findfile_action_for/) fixes the problem, since (from what I got) the idea is to call `pug-compile` for .pug files anyway.